### PR TITLE
fix: optimized query - fix $or operator and add support for nested operators

### DIFF
--- a/docs/guide/paginated-optimized-query.md
+++ b/docs/guide/paginated-optimized-query.md
@@ -281,18 +281,49 @@ query.where({
 });
 ```
 
-**Note :** Par défaut, plusieurs conditions dans `where()` sont combinées avec AND, donc `$and` est optionnel dans la plupart des cas.
+> **Note :** Par défaut, plusieurs conditions dans `where()` sont combinées avec AND, donc `$and` est optionnel dans la plupart des cas.
 
 ##### $or - Au moins une condition doit être vraie
 
-Pour simuler un OR sur la même colonne, utilisez IN :
-
 ```javascript
-// OR sur même colonne → utilisez IN
 query.where({
-  status: ['SUBMITTED', 'VALIDATED']  // Équivalent à OR
+  $or: [
+    { applicant_id: null },
+    { pme_folder_id: null }
+  ]
+});
+// → WHERE (applicant_id IS NULL OR pme_folder_id IS NULL)
+```
+
+> **Note :** Pour simuler un OR sur la même colonne, utilisez IN :
+```javascript
+query.where({
+  status: ['SUBMITTED', 'VALIDATED']
 });
 // → WHERE status IN ('SUBMITTED', 'VALIDATED')
+```
+
+##### Imbrication $or / $and
+
+`$or` et `$and` peuvent être imbriqués à n'importe quel niveau :
+
+```javascript
+query.where({
+  type: 'agp',
+  $or: [
+    { applicant_id: null },
+    {
+      $and: [
+        { pme_folder_id: null },
+        { $or: [
+          { status: { $like: 'TRANS%' } },
+          { status: 'DRAFT' }
+        ]}
+      ]
+    }
+  ]
+});
+// → WHERE (applicant_id IS NULL OR (pme_folder_id IS NULL AND (status LIKE 'TRANS%' OR status = 'DRAFT'))) AND type = 'agp'
 ```
 
 ### .join(associations)
@@ -578,13 +609,13 @@ query.where({
 
 ## Tri sur colonnes jointes
 
-PaginatedOptimizedQuery détecte automatiquement les colonnes de tri qui proviennent de tables jointes et ajoute les INNER JOIN nécessaires dans la phase `SELECT IDS`.
+PaginatedOptimizedQuery détecte automatiquement les colonnes de tri qui proviennent de tables jointes et ajoute les LEFT JOIN nécessaires dans la phase `SELECT IDS`.
 
 Cette fonctionnalité garantit que :
 - Le tri est effectué côté base de données (rapide)
 - La pagination renvoie les bons résultats triés
-- Les INNER JOIN sont ajoutés uniquement dans la phase IDS (pas dans COUNT)
-- Les tables imbriquées sont gérées avec des INNER JOIN en cascade
+- Les LEFT JOIN sont ajoutés uniquement dans la phase IDS (pas dans COUNT)
+- Les tables imbriquées sont gérées avec des LEFT JOIN en cascade
 
 ### Détection Automatique
 
@@ -648,7 +679,7 @@ SQL généré (phase IDS) :
 ```sql
 SELECT `folders`.`id`
 FROM `folders`
-INNER JOIN `applicants` ON `applicants`.`id` = `folders`.`applicant_id`
+LEFT JOIN `applicants` ON `applicants`.`id` = `folders`.`applicant_id`
 WHERE `folders`.`type` IN ('agp', 'avt')
   AND EXISTS (
     SELECT 1 FROM `applicants`
@@ -801,7 +832,7 @@ Les agrégations avec `GROUP BY` sur plusieurs tables ne sont pas supportées.
 ### Fichiers créés
 
 - `src/db/PaginatedOptimizedQuery.js` - Classe principale héritant de `Query`
-- `src/db/PaginatedOptimizedSql.js` - Générateur SQL avec EXISTS et INNER JOIN pour tri
+- `src/db/PaginatedOptimizedSql.js` - Générateur SQL avec EXISTS et LEFT JOIN pour tri
 - `test/db/PaginatedOptimizedQueryTest.js` - Tests unitaires
 - `examples/PaginatedOptimizedQueryExample.js` - Exemples complets d'utilisation (10 exemples)
 
@@ -849,7 +880,7 @@ Les exemples se trouvent dans :
 
 Pour améliorer `PaginatedOptimizedQuery`, veuillez :
 
-1. Ajouter des tests dans `test/db/SimplifiedSyntaxTest.js`
+1. Ajouter des tests dans `test/db/PaginatedOptimizedQueryTest.js`
 2. Documenter les changements dans ce fichier
 3. Mettre à jour les exemples si nécessaire
 

--- a/src/db/PaginatedOptimizedQuery.js
+++ b/src/db/PaginatedOptimizedQuery.js
@@ -168,99 +168,18 @@ module.exports = class PaginatedOptimizedQuery extends Query {
    * @returns {PaginatedOptimizedQuery} this (pour chaînage)
    */
   where(where, params) {
-    // Appeler le parent pour gérer les cas simples (string avec params)
     if (params !== undefined) {
       return super.where(where, params);
     }
 
-    // Cas spécial : $or avec des conditions sur tables jointes
-    // Ces conditions doivent être transformées en filterJoin avec OR
-    // Les autres conditions du même objet sont traitées séparément
-    if (where.$or && _.isArray(where.$or)) {
-      this._handleOrWithJoinedTables(where.$or);
-      const siblingConditions = _.omit(where, '$or');
-      if (!_.isEmpty(siblingConditions)) {
-        this.where(siblingConditions);
-      }
-      return this;
+    const joinConditions = {};
+    const { sql, params: compiledParams } = this._compileExpression(where, joinConditions);
+
+    if (sql) {
+      super.where(sql, compiledParams);
     }
 
-    // Analyser et transformer les conditions
-    const { mainConditions, joinConditions } = this._parseWhereConditions(where);
-
-    // Ajouter les conditions sur la table principale
-    // mainConditions est maintenant un tableau de conditions
-    if (mainConditions && mainConditions.length > 0) {
-      _.forEach(mainConditions, (cond) => {
-        // Cas 1 : c'est un array d'objets (vient d'un $or)
-        // Il faut le transformer en SQL avec OR car Query ne gère pas $or
-        if (_.isArray(cond) && cond.length > 0) {
-          // Construire manuellement la clause OR
-          const orClauses = [];
-          const orParams = [];
-
-          _.forEach(cond, (orCond) => {
-            if (_.isObject(orCond)) {
-              const condClauses = [];
-              _.forOwn(orCond, (value, key) => {
-                const columnRef = `\`${this.query.table}\`.\`${key}\``;
-
-                if (value === null || value === undefined) {
-                  condClauses.push(`${columnRef} IS NULL`);
-                } else if (_.isArray(value)) {
-                  if (value.length === 0) {
-                    condClauses.push('FALSE');
-                  } else {
-                    condClauses.push(`${columnRef} IN ($?)`);
-                    orParams.push(value);
-                  }
-                } else if (_.isString(value) && value.includes('%')) {
-                  // Pattern LIKE détecté
-                  condClauses.push(`${columnRef} LIKE $?`);
-                  orParams.push(value);
-                } else {
-                  condClauses.push(`${columnRef} = $?`);
-                  orParams.push(value);
-                }
-              });
-
-              if (condClauses.length > 0) {
-                orClauses.push(condClauses.length > 1 ? `(${condClauses.join(' AND ')})` : condClauses[0]);
-              }
-            }
-          });
-
-          if (orClauses.length > 0) {
-            const orSQL = `(${orClauses.join(' OR ')})`;
-            super.where(orSQL, orParams);
-          }
-        }
-        // Cas 2 : c'est un objet avec des valeurs SQL transformées
-        else if (_.isObject(cond) && !_.isArray(cond)) {
-          const normalizedCond = {};
-          _.forOwn(cond, (value, key) => {
-            // Si la valeur est un tableau [sql, params] avec $? dans le SQL
-            if (_.isArray(value) && value.length === 2 && _.isString(value[0]) && value[0].includes('$?')) {
-              super.where(value[0], value[1]);
-            } else {
-              normalizedCond[key] = value;
-            }
-          });
-
-          // Ajouter les conditions normales si présentes
-          if (!_.isEmpty(normalizedCond)) {
-            super.where(normalizedCond);
-          }
-        }
-        // Cas 3 : autre format (ne devrait pas arriver)
-        else {
-          super.where(cond);
-        }
-      });
-    }
-
-    // Générer automatiquement les filterJoins pour les conditions sur tables jointes
-    if (joinConditions && Object.keys(joinConditions).length > 0) {
+    if (Object.keys(joinConditions).length > 0) {
       this._buildFilterJoinsFromPaths(joinConditions);
     }
 
@@ -587,212 +506,174 @@ module.exports = class PaginatedOptimizedQuery extends Query {
   }
 
   /**
-   * Gère les conditions $or qui contiennent des tables jointes
+   * Compile récursivement une expression de conditions en SQL
    *
-   * Crée un filterJoin spécial de type 'or_group' qui combine toutes les
-   * conditions avec OR au lieu de AND.
+   * Gère : $and, $or, AND implicite entre clés, et les conditions unitaires.
+   * Les clés avec `.` (joined tables) sont collectées dans joinConditions
+   * pour être traitées via filterJoins.
    *
-   * @param {Array} orConditions - Array de conditions du $or
+   * @param {object} expr - Expression de conditions
+   * @param {object} joinConditions - Accumulateur pour les conditions sur tables jointes (mutated)
+   * @returns {{ sql: string, params: Array }} Clause SQL compilée et ses paramètres
    */
-  _handleOrWithJoinedTables(orConditions) {
-    // Séparer les conditions principales et jointes
-    const mainTableConditions = [];
-    const joinedTableConditions = [];
+  _compileExpression(expr, joinConditions) {
+    if (!expr || _.isEmpty(expr)) {
+      return { sql: '', params: [] };
+    }
 
-    _.forEach(orConditions, (cond) => {
-      const hasJoinedTable = _.some(_.keys(cond), key => key.includes('.'));
+    // $and explicite
+    if (expr.$and && _.isArray(expr.$and)) {
+      const parts = [];
+      const allParams = [];
 
-      if (hasJoinedTable) {
-        // Condition sur table jointe
-        joinedTableConditions.push(cond);
-      } else {
-        // Condition sur table principale
-        mainTableConditions.push(cond);
+      _.forEach(expr.$and, (child) => {
+        const compiled = this._compileExpression(child, joinConditions);
+        if (compiled.sql) {
+          parts.push(compiled.sql);
+          allParams.push(...compiled.params);
+        }
+      });
+
+      // Traiter les clés siblings (hors $and)
+      const siblings = _.omit(expr, '$and');
+      if (!_.isEmpty(siblings)) {
+        const compiled = this._compileExpression(siblings, joinConditions);
+        if (compiled.sql) {
+          parts.push(compiled.sql);
+          allParams.push(...compiled.params);
+        }
       }
-    });
 
-    // Traiter les conditions sur table principale avec OR
-    // Chaque élément du tableau est une branche OR ; si une branche a plusieurs clés, elles sont combinées avec AND
-    if (mainTableConditions.length > 0) {
-      const orBranches = [];
-      const orParams = [];
+      if (parts.length === 0) return { sql: '', params: [] };
+      if (parts.length === 1) return { sql: parts[0], params: allParams };
+      return { sql: `(${parts.join(' AND ')})`, params: allParams };
+    }
 
-      _.forEach(mainTableConditions, (cond) => {
-        const branchClauses = [];
+    // $or explicite
+    if (expr.$or && _.isArray(expr.$or)) {
+      const allParts = [];
+      const allParams = [];
 
-        _.forOwn(cond, (value, key) => {
-          const columnRef = `\`${this.query.table}\`.\`${key}\``;
+      // Séparer les branches avec/sans conditions sur tables jointes
+      const orParts = [];
+      const orJoinedConditions = [];
 
-          if (value === null || value === undefined) {
-            branchClauses.push(`${columnRef} IS NULL`);
-          } else if (_.isArray(value)) {
-            if (value.length === 0) {
-              branchClauses.push('FALSE');
-            } else {
-              branchClauses.push(`${columnRef} IN ($?)`);
-              orParams.push(value);
-            }
-          } else if (_.isString(value) && value.includes('%')) {
-            branchClauses.push(`${columnRef} LIKE $?`);
-            orParams.push(value);
-          } else {
-            branchClauses.push(`${columnRef} = $?`);
-            orParams.push(value);
+      _.forEach(expr.$or, (child) => {
+        const hasJoinedKey = _.isObject(child) && !_.isArray(child) &&
+          _.some(_.keys(child), k => k.includes('.') && !k.startsWith('$'));
+
+        if (hasJoinedKey) {
+          orJoinedConditions.push(child);
+        } else {
+          const compiled = this._compileExpression(child, joinConditions);
+          if (compiled.sql) {
+            orParts.push(compiled.sql);
+            allParams.push(...compiled.params);
           }
+        }
+      });
+
+      // Les conditions jointes dans un $or → or_group filterJoin (OR-ed EXISTS)
+      if (orJoinedConditions.length > 0) {
+        this.query.filterJoins.push({
+          type: 'or_group',
+          conditions: orJoinedConditions
         });
-
-        if (branchClauses.length === 1) {
-          orBranches.push(branchClauses[0]);
-        } else if (branchClauses.length > 1) {
-          orBranches.push(`(${branchClauses.join(' AND ')})`);
-        }
-      });
-
-      const orSQL = `(${orBranches.join(' OR ')})`;
-      super.where(orSQL, orParams);
-    }
-
-    // Traiter les conditions sur tables jointes
-    // Créer un filterJoin spécial qui sera traité comme un groupe OR
-    if (joinedTableConditions.length > 0) {
-      this.query.filterJoins.push({
-        type: 'or_group',
-        conditions: joinedTableConditions
-      });
-    }
-  }
-
-  /**
-   * Parse les conditions where pour séparer :
-   * - Les conditions sur la table principale
-   * - Les conditions sur les tables jointes (chemins avec points)
-   *
-   * @param {object} conditions - Objet de conditions
-   * @returns {object} { mainConditions, joinConditions }
-   *
-   * Exemple :
-   * Input: {
-   *   $and: [
-   *     { status: 'ACTIVE' },
-   *     { 'applicant.last_name': 'Dupont' },
-   *     { 'pme_folder.company.country.code': 'FR' }
-   *   ]
-   * }
-   *
-   * Output: {
-   *   mainConditions: [{ status: 'ACTIVE' }],  // Tableau de conditions
-   *   joinConditions: {
-   *     'applicant.last_name': { value: 'Dupont', path: ['applicant'], column: 'last_name' },
-   *     'pme_folder.company.country.code': { value: 'FR', path: ['pme_folder', 'company', 'country'], column: 'code' }
-   *   }
-   * }
-   */
-  _parseWhereConditions(conditions) {
-    const mainConditions = [];
-    const joinConditions = {};
-
-    // Gérer les opérateurs logiques $and et $or
-    if (conditions.$and) {
-      // $and : aplatir les conditions sur la table principale
-      _.forEach(conditions.$and, (cond) => {
-        const parsed = this._parseConditionObject(cond);
-        if (parsed.main && !_.isEmpty(parsed.main)) {
-          mainConditions.push(parsed.main);
-        }
-        Object.assign(joinConditions, parsed.join);
-      });
-    } else if (conditions.$or) {
-      // $or : gérer les conditions imbriquées
-      // Note: Si toutes les conditions du $or sont sur la table principale,
-      // on peut les regrouper. Sinon, on doit les traiter séparément.
-      const orMainConditions = [];
-      _.forEach(conditions.$or, (cond) => {
-        const parsed = this._parseConditionObject(cond);
-        if (parsed.main && !_.isEmpty(parsed.main)) {
-          orMainConditions.push(parsed.main);
-        }
-        Object.assign(joinConditions, parsed.join);
-      });
-
-      // Si on a des conditions sur la table principale dans le $or
-      if (orMainConditions.length > 0) {
-        mainConditions.push(orMainConditions);
       }
-    } else {
-      // Cas simple : objet de conditions
-      const parsed = this._parseConditionObject(conditions);
-      if (parsed.main && !_.isEmpty(parsed.main)) {
-        mainConditions.push(parsed.main);
+
+      if (orParts.length > 0) {
+        allParts.push(`(${orParts.join(' OR ')})`);
       }
-      Object.assign(joinConditions, parsed.join);
+
+      // Puis les clés siblings (hors $or)
+      const siblings = _.omit(expr, '$or');
+      if (!_.isEmpty(siblings)) {
+        const compiled = this._compileExpression(siblings, joinConditions);
+        if (compiled.sql) {
+          allParts.push(compiled.sql);
+          allParams.push(...compiled.params);
+        }
+      }
+
+      if (allParts.length === 0) return { sql: '', params: [] };
+      if (allParts.length === 1) return { sql: allParts[0], params: allParams };
+      return { sql: allParts.join(' AND '), params: allParams };
     }
 
-    return { mainConditions, joinConditions };
-  }
+    // Objet de conditions simples : AND implicite entre les clés
+    const parts = [];
+    const allParams = [];
 
-  /**
-   * Parse un objet de conditions pour séparer les colonnes principales et jointes
-   *
-   * @param {object} conditionObj - Objet de conditions { column: value, ... }
-   * @returns {object} { main: {...}, join: {...} }
-   */
-  _parseConditionObject(conditionObj) {
-    const main = {};
-    const join = {};
-
-    _.forOwn(conditionObj, (value, key) => {
-      // Détecter si la clé contient un point (chemin vers table jointe)
+    _.forOwn(expr, (value, key) => {
       if (key.includes('.')) {
-        // Extraire le chemin et la colonne finale
-        const parts = key.split('.');
-        const column = parts[parts.length - 1];
-        const path = parts.slice(0, -1); // ['applicant'] ou ['pme_folder', 'company', 'country']
-
-        join[key] = {
-          value,
-          path,
-          column
-        };
+        // Condition sur table jointe : collecter pour filterJoins
+        const keyParts = key.split('.');
+        const column = keyParts[keyParts.length - 1];
+        const path = keyParts.slice(0, -1);
+        joinConditions[key] = { value, path, column };
       } else {
-        // Condition sur la table principale
-        // Transformer les opérateurs spéciaux en SQL avant de les ajouter
-        main[key] = this._transformOperator(key, value);
+        const compiled = this._compileSingleCondition(key, value);
+        if (compiled.sql) {
+          parts.push(compiled.sql);
+          allParams.push(...compiled.params);
+        }
       }
     });
 
-    return { main, join };
+    if (parts.length === 0) return { sql: '', params: [] };
+    if (parts.length === 1) return { sql: parts[0], params: allParams };
+    return { sql: `(${parts.join(' AND ')})`, params: allParams };
   }
 
   /**
-   * Transforme les opérateurs spéciaux en SQL
+   * Compile une condition unitaire (colonne + valeur) en SQL
    *
    * @param {string} column - Nom de la colonne
-   * @param {any} value - Valeur (peut contenir des opérateurs)
-   * @returns {any} Valeur transformée ou SQL string avec params
+   * @param {any} value - Valeur ou opérateur ($like, $gte, etc.)
+   * @returns {{ sql: string, params: Array }}
    */
-  _transformOperator(column, value) {
-    // Si la valeur n'est pas un objet, la retourner telle quelle
-    if (!_.isObject(value) || _.isArray(value) || _.isDate(value)) {
-      return value;
+  _compileSingleCondition(column, value) {
+    const columnRef = `\`${this.query.table}\`.\`${column}\``;
+
+    if (value === null || value === undefined) {
+      return { sql: `${columnRef} IS NULL`, params: [] };
     }
 
-    // Transformer les opérateurs spéciaux en SQL
-    if (value.$between && _.isArray(value.$between) && value.$between.length === 2) {
-      return [`\`${this.schema.table}\`.\`${column}\` BETWEEN $? AND $?`, value.$between];
-    } else if (value.$gte !== undefined) {
-      return [`\`${this.schema.table}\`.\`${column}\` >= $?`, value.$gte];
-    } else if (value.$lte !== undefined) {
-      return [`\`${this.schema.table}\`.\`${column}\` <= $?`, value.$lte];
-    } else if (value.$gt !== undefined) {
-      return [`\`${this.schema.table}\`.\`${column}\` > $?`, value.$gt];
-    } else if (value.$lt !== undefined) {
-      return [`\`${this.schema.table}\`.\`${column}\` < $?`, value.$lt];
-    } else if (value.$like !== undefined) {
-      return [`\`${this.schema.table}\`.\`${column}\` LIKE $?`, value.$like];
+    if (_.isArray(value)) {
+      if (value.length === 0) {
+        return { sql: 'FALSE', params: [] };
+      }
+      return { sql: `${columnRef} IN ($?)`, params: [value] };
     }
 
-    // Sinon, retourner la valeur telle quelle
-    return value;
+    // Opérateurs sous forme d'objet : $like, $between, $gte, $lte, $gt, $lt
+    if (_.isObject(value) && !_.isDate(value)) {
+      if (value.$like !== undefined) {
+        return { sql: `${columnRef} LIKE $?`, params: [value.$like] };
+      }
+      if (value.$between && _.isArray(value.$between) && value.$between.length === 2) {
+        return { sql: `${columnRef} BETWEEN $? AND $?`, params: value.$between };
+      }
+      if (value.$gte !== undefined) {
+        return { sql: `${columnRef} >= $?`, params: [value.$gte] };
+      }
+      if (value.$lte !== undefined) {
+        return { sql: `${columnRef} <= $?`, params: [value.$lte] };
+      }
+      if (value.$gt !== undefined) {
+        return { sql: `${columnRef} > $?`, params: [value.$gt] };
+      }
+      if (value.$lt !== undefined) {
+        return { sql: `${columnRef} < $?`, params: [value.$lt] };
+      }
+    }
+
+    // String avec % → LIKE implicite
+    if (_.isString(value) && value.includes('%')) {
+      return { sql: `${columnRef} LIKE $?`, params: [value] };
+    }
+
+    return { sql: `${columnRef} = $?`, params: [value] };
   }
 
   /**

--- a/src/db/PaginatedOptimizedQuery.js
+++ b/src/db/PaginatedOptimizedQuery.js
@@ -175,8 +175,13 @@ module.exports = class PaginatedOptimizedQuery extends Query {
 
     // Cas spécial : $or avec des conditions sur tables jointes
     // Ces conditions doivent être transformées en filterJoin avec OR
+    // Les autres conditions du même objet sont traitées séparément
     if (where.$or && _.isArray(where.$or)) {
       this._handleOrWithJoinedTables(where.$or);
+      const siblingConditions = _.omit(where, '$or');
+      if (!_.isEmpty(siblingConditions)) {
+        this.where(siblingConditions);
+      }
       return this;
     }
 
@@ -607,37 +612,44 @@ module.exports = class PaginatedOptimizedQuery extends Query {
     });
 
     // Traiter les conditions sur table principale avec OR
+    // Chaque élément du tableau est une branche OR ; si une branche a plusieurs clés, elles sont combinées avec AND
     if (mainTableConditions.length > 0) {
-      const orClauses = [];
+      const orBranches = [];
       const orParams = [];
 
       _.forEach(mainTableConditions, (cond) => {
+        const branchClauses = [];
+
         _.forOwn(cond, (value, key) => {
           const columnRef = `\`${this.query.table}\`.\`${key}\``;
 
           if (value === null || value === undefined) {
-            orClauses.push(`${columnRef} IS NULL`);
+            branchClauses.push(`${columnRef} IS NULL`);
           } else if (_.isArray(value)) {
             if (value.length === 0) {
-              orClauses.push('FALSE');
+              branchClauses.push('FALSE');
             } else {
-              orClauses.push(`${columnRef} IN ($?)`);
+              branchClauses.push(`${columnRef} IN ($?)`);
               orParams.push(value);
             }
           } else if (_.isString(value) && value.includes('%')) {
-            orClauses.push(`${columnRef} LIKE $?`);
+            branchClauses.push(`${columnRef} LIKE $?`);
             orParams.push(value);
           } else {
-            orClauses.push(`${columnRef} = $?`);
+            branchClauses.push(`${columnRef} = $?`);
             orParams.push(value);
           }
         });
+
+        if (branchClauses.length === 1) {
+          orBranches.push(branchClauses[0]);
+        } else if (branchClauses.length > 1) {
+          orBranches.push(`(${branchClauses.join(' AND ')})`);
+        }
       });
 
-      if (orClauses.length > 0) {
-        const orSQL = `(${orClauses.join(' OR ')})`;
-        super.where(orSQL, orParams);
-      }
+      const orSQL = `(${orBranches.join(' OR ')})`;
+      super.where(orSQL, orParams);
     }
 
     // Traiter les conditions sur tables jointes

--- a/test/db/PaginatedOptimizedQueryTest.js
+++ b/test/db/PaginatedOptimizedQueryTest.js
@@ -428,6 +428,54 @@ describe('db.PaginatedOptimizedQuery', function() {
       assert.ok(sql.sql.includes('EXISTS'), 'Should include EXISTS for applicant');
     });
 
+    it('should handle $or with multiple conditions', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        $or: [
+          { applicant_id: null },
+          { pme_folder_id: null }
+        ]
+      });
+
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR `folders`.`pme_folder_id` IS NULL)'));
+    });
+
+    it('should include sibling conditions alongside $or', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        status: 'TRANSMIS',
+        $or: [
+          { applicant_id: null },
+          { pme_folder_id: null }
+        ]
+      });
+
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR `folders`.`pme_folder_id` IS NULL) AND `folders`.`status` = ?'));
+      assert.deepStrictEqual(params, ['TRANSMIS']);
+    });
+
+    it('should group multiple keys in one $or branch as implicit AND', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        $or: [
+          { applicant_id: null },
+          { pme_folder_id: null, type: 'agp' }
+        ]
+      });
+
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR (`folders`.`pme_folder_id` IS NULL AND `folders`.`type` = ?))'));
+      assert.deepStrictEqual(params, ['agp']);
+    });
+
     it('should combine main table and joined table filters', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';

--- a/test/db/PaginatedOptimizedQueryTest.js
+++ b/test/db/PaginatedOptimizedQueryTest.js
@@ -476,6 +476,50 @@ describe('db.PaginatedOptimizedQuery', function() {
       assert.deepStrictEqual(params, ['agp']);
     });
 
+    it('should generate OR-ed EXISTS for $or with joined table conditions', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        $or: [
+          { 'applicant.last_name': 'Dupont%' },
+          { 'pme_folder.status': 'ACTIVE' }
+        ]
+      });
+
+      const { sql, params } = query.toSQL();
+
+      // Les deux EXISTS doivent être reliés par OR (pas AND)
+      assert.ok(sql.includes('(EXISTS (SELECT 1 FROM `applicants`'), 'Should have EXISTS on applicants');
+      assert.ok(sql.includes('OR EXISTS (SELECT 1 FROM `pme_folders`'), 'Should have OR EXISTS on pme_folders');
+    });
+
+    it('should support arbitrarily nested $or / $and expressions', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        type: 'agp',
+        $or: [
+          { applicant_id: null },
+          {
+            $and: [
+              { pme_folder_id: null },
+              { $or: [
+                { status: { $like: 'TRANS%' } },
+                { status: 'DRAFT' }
+              ]}
+            ]
+          }
+        ]
+      });
+
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes(
+        'WHERE (`folders`.`applicant_id` IS NULL OR (`folders`.`pme_folder_id` IS NULL AND (`folders`.`status` LIKE ? OR `folders`.`status` = ?))) AND `folders`.`type` = ?'
+      ));
+      assert.deepStrictEqual(params, ['TRANS%', 'DRAFT', 'agp']);
+    });
+
     it('should combine main table and joined table filters', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';

--- a/test/db/PaginatedOptimizedQueryTest.js
+++ b/test/db/PaginatedOptimizedQueryTest.js
@@ -1,12 +1,9 @@
-// Tests unitaires sans dépendance sur la base de données
-// On teste uniquement la génération SQL, pas l'exécution
-
 const assert = require('assert');
 
 const PaginatedOptimizedQuery = require('../../src/db/PaginatedOptimizedQuery');
+const PaginatedOptimizedSql = require('../../src/db/PaginatedOptimizedSql');
 const Model = require('../../src/db/Model');
 
-// Helper pour mocker getDb
 const mockGetDb = (query) => {
   query.getDb = () => ({
     driver: {
@@ -22,10 +19,8 @@ const mockGetDb = (query) => {
   return query;
 };
 
-//
 describe('db.PaginatedOptimizedQuery', function() {
 
-  // Définition des modèles de test
   class Country extends Model({
     table: 'countries',
     columns: {
@@ -64,11 +59,8 @@ describe('db.PaginatedOptimizedQuery', function() {
     ]
   }) {}
 
-  // Separate class to avoid circular dependencies in test setup
-  // This will be used for testing nested block paths
   class PmeFolderWithBlocks extends PmeFolder {}
 
-  // Define associations after class declaration to handle forward references
   PmeFolderWithBlocks.schema.columns.block_studies_id = 'integer';
   PmeFolderWithBlocks.schema.columns.block_travel_wishes_id = 'integer';
   PmeFolderWithBlocks.schema.colsByName = PmeFolderWithBlocks.schema.colsByName || {};
@@ -103,7 +95,6 @@ describe('db.PaginatedOptimizedQuery', function() {
     ]
   }) {}
 
-  // Modèles de test pour les "blocks" (sous-tables)
   class StudiesBlock extends Model({
     table: 'block_studies',
     primary: ['id'],
@@ -128,14 +119,12 @@ describe('db.PaginatedOptimizedQuery', function() {
     ]
   }) {}
 
-  // Now add block associations to PmeFolderWithBlocks (must be after block classes are defined)
   PmeFolderWithBlocks.schema.associations = [
     ['belongs_to', 'company', Company, 'company_id', 'id'],
     ['belongs_to', 'block_study', StudiesBlock, 'block_studies_id', 'id'],
     ['belongs_to', 'block_travel_wish', TravelWishesBlock, 'block_travel_wishes_id', 'id']
   ];
 
-  // Folder variant with PmeFolderWithBlocks for testing nested block paths
   class FolderWithNestedBlocks extends Model({
     table: 'folders',
     primary: ['id'],
@@ -169,298 +158,184 @@ describe('db.PaginatedOptimizedQuery', function() {
     ]
   }) {}
 
-  //
-  describe('Simplified Syntax - where() with nested paths', function() {
-    it('should detect simple path (1 level)', () => {
-      const query = new PaginatedOptimizedQuery(Folder);
-      query.where({
-        status: 'SUBMITTED',
-        'applicant.last_name': 'Dupont'
-      });
+  class Library extends Model({
+    table: 'libraries',
+    primary: ['id'],
+    columns: {
+      id: 'integer',
+      title: 'string',
+      collection: 'string'
+    }
+  }) {}
 
-      // Vérifier que filterJoins a été créé
-      assert.ok(query.query.filterJoins.length > 0, 'filterJoins should contain at least one element');
+  class BookWithExtraWhere extends Model({
+    table: 'books',
+    primary: ['id'],
+    columns: {
+      id: 'integer',
+      code: 'string',
+      title: 'string',
+      library_id: 'integer'
+    },
+    associations: () => ([
+      ['belongs_to', 'library', Library, 'library_id', 'id', { collection: 'A' }]
+    ])
+  }) {}
 
-      // Vérifier que le filtre sur la table principale est dans where
-      assert.ok(query.query.where.length > 0, 'where should contain the condition on status');
+  class BookWithMultipleExtraWhere extends Model({
+    table: 'books_multi',
+    primary: ['id'],
+    columns: {
+      id: 'integer',
+      title: 'string',
+      library_id: 'integer'
+    },
+    associations: () => ([
+      ['belongs_to', 'library', Library, 'library_id', 'id', { collection: 'A', title: 'Main' }]
+    ])
+  }) {}
+
+  // -------------------------------------------------------
+  // 1. Unit operators
+  // -------------------------------------------------------
+  describe('Unit operators on main table', function() {
+    it('should generate equality condition', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ status: 'SUBMITTED' });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE `folders`.`status` = ?'));
+      assert.deepStrictEqual(params, ['SUBMITTED']);
     });
 
-    it('should detect nested path (3 levels)', () => {
-      const query = new PaginatedOptimizedQuery(Folder);
-      query.where({
-        'pme_folder.company.country.code': 'FR'
-      });
+    it('should generate IS NULL', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ applicant_id: null });
+      const { sql } = query.toSQL();
 
-      // Vérifier que filterJoins nested a été créé
-      assert.ok(query.query.filterJoins.length > 0, 'filterJoins should be created');
-      assert.equal(query.query.filterJoins[0].type, 'nested', 'filterJoin should be of type nested');
+      assert.ok(sql.includes('`folders`.`applicant_id` IS NULL'));
     });
 
-    it('should group conditions on the same table', () => {
-      const query = new PaginatedOptimizedQuery(Folder);
-      query.where({
-        'applicant.last_name': 'Dupont',
-        'applicant.first_name': 'Jean',
-        'applicant.email': 'test@test.com'
-      });
+    it('should generate IN for array values', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ status: ['SUBMITTED', 'VALIDATED'] });
+      const { sql, params } = query.toSQL();
 
-      // Vérifier qu'un seul filterJoin a été créé (regroupement)
-      assert.equal(query.query.filterJoins.length, 1, 'Should create a single filterJoin for applicant');
+      assert.ok(sql.includes('WHERE `folders`.`status` IN (?)'));
+      assert.deepStrictEqual(params, [['SUBMITTED', 'VALIDATED']]);
+    });
+
+    it('should generate FALSE for empty array', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ status: [] });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE FALSE'));
+      assert.deepStrictEqual(params, []);
+    });
+
+    it('should generate implicit LIKE for string with %', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ status: 'TRANS%' });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE `folders`.`status` LIKE ?'));
+      assert.deepStrictEqual(params, ['TRANS%']);
+    });
+
+    it('should generate explicit $like', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ status: { $like: 'TRANS%' } });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE `folders`.`status` LIKE ?'));
+      assert.deepStrictEqual(params, ['TRANS%']);
+    });
+
+    it('should generate $between', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ created_at: { $between: ['2024-01-01', '2024-12-31'] } });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('WHERE `folders`.`created_at` BETWEEN ? AND ?'));
+      assert.deepStrictEqual(params, ['2024-01-01', '2024-12-31']);
+    });
+
+    it('should generate $gte, $lte, $gt, $lt', () => {
+      const operators = [
+        { op: '$gte', symbol: '>=' },
+        { op: '$lte', symbol: '<=' },
+        { op: '$gt',  symbol: '>'  },
+        { op: '$lt',  symbol: '<'  },
+      ];
+
+      for (const { op, symbol } of operators) {
+        const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+        query.query.verb = 'count';
+        query.where({ created_at: { [op]: '2024-01-01' } });
+        const { sql, params } = query.toSQL();
+
+        assert.ok(sql.includes(`WHERE \`folders\`.\`created_at\` ${symbol} ?`), `${op} should produce ${symbol}`);
+        assert.deepStrictEqual(params, ['2024-01-01']);
+      }
     });
   });
 
-  //
-  describe('countSQL with EXISTS', function() {
-    it('should generate COUNT SQL with EXISTS for nested paths', () => {
+  // -------------------------------------------------------
+  // 2. Logical operators
+  // -------------------------------------------------------
+  describe('Logical operators', function() {
+    it('should generate implicit AND', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
-      query.where({
-        type: ['agp', 'avt'],
-        'applicant.last_name': 'Dupont%'
-      });
+      query.where({ status: 'SUBMITTED', type: 'agp' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Vérifier que le SQL contient EXISTS
-      assert.ok(sql.sql.includes('EXISTS'), 'SQL should contain EXISTS');
-      assert.ok(sql.sql.includes('SELECT 1 FROM'), 'SQL should contain SELECT 1 FROM');
-      assert.ok(sql.sql.includes('applicants'), 'SQL should reference applicants table');
-      assert.ok(sql.sql.includes('COUNT(0)'), 'SQL should contain COUNT(0)');
-
-      // Vérifier qu'il n'y a pas de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'SQL should not contain LEFT JOIN');
+      assert.ok(sql.includes('WHERE (`folders`.`status` = ? AND `folders`.`type` = ?)'));
+      assert.deepStrictEqual(params, ['SUBMITTED', 'agp']);
     });
 
-    it('should generate COUNT SQL with multiple EXISTS', () => {
+    it('should generate explicit $and', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
-      query.where({
-        type: 'agp',
-        'applicant.last_name': 'Dupont%',
-        'pme_folder.status': 'ACTIVE'
-      });
+      query.where({ $and: [{ status: 'SUBMITTED' }, { type: 'agp' }] });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Vérifier qu'il y a 2 EXISTS
-      const existsCount = (sql.sql.match(/EXISTS/g) || []).length;
-      assert.strictEqual(existsCount, 2, 'SQL should contain 2 EXISTS clauses');
-
-      // Vérifier les tables
-      assert.ok(sql.sql.includes('applicants'), 'SQL should reference applicants');
-      assert.ok(sql.sql.includes('pme_folders'), 'SQL should reference pme_folders');
+      assert.ok(sql.includes('WHERE (`folders`.`status` = ? AND `folders`.`type` = ?)'));
+      assert.deepStrictEqual(params, ['SUBMITTED', 'agp']);
     });
 
-    it('should generate nested EXISTS for deep paths', () => {
+    it('should generate simple $or', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
-      query.where({
-        'pme_folder.company.country.code': 'FR'
-      });
-
-      const sql = query.toSQL();
-
-      // Vérifier que des EXISTS imbriqués sont générés
-      const existsCount = (sql.sql.match(/EXISTS/g) || []).length;
-      assert.ok(existsCount >= 3, 'SQL should contain at least 3 nested EXISTS');
-
-      // Vérifier que les tables sont mentionnées
-      assert.ok(sql.sql.includes('pme_folders'), 'SQL should reference pme_folders');
-      assert.ok(sql.sql.includes('companies'), 'SQL should reference companies');
-      assert.ok(sql.sql.includes('countries'), 'SQL should reference countries');
-    });
-  });
-
-  //
-  describe('idsSQL', function() {
-    it('should generate SELECT IDs SQL with EXISTS', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query.where({
-        type: 'agp',
-        'applicant.last_name': 'Dupont%'
-      })
-      .order('folders.created_at DESC')
-      .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier la structure
-      assert.ok(sql.sql.includes('SELECT'), 'SQL should contain SELECT');
-      assert.ok(sql.sql.includes('`folders`.`id`'), 'SQL should select folders.id');
-      assert.ok(sql.sql.includes('EXISTS'), 'SQL should contain EXISTS');
-      assert.ok(sql.sql.includes('ORDER BY'), 'SQL should contain ORDER BY');
-      assert.ok(sql.sql.includes('LIMIT'), 'SQL should contain LIMIT');
-
-      // Pas de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'SQL should not contain LEFT JOIN');
-    });
-  });
-
-  //
-  describe('Model.paginatedOptimized()', function() {
-    it('should return PaginatedOptimizedQuery instance', () => {
-      const query = Folder.paginatedOptimized();
-      assert.ok(query instanceof PaginatedOptimizedQuery, 'Should return PaginatedOptimizedQuery instance');
-      assert.strictEqual(query.query.optimized, true, 'Query should be marked as optimized');
-    });
-
-    it('should support method chaining with new syntax', () => {
-      const query = Folder.paginatedOptimized()
-        .where({
-          type: 'agp',
-          'applicant.last_name': 'Dupont%'
-        })
-        .order('folders.created_at DESC');
-
-      assert.strictEqual(query.query.where.length, 1);
-      assert.strictEqual(query.query.filterJoins.length, 1);
-      assert.strictEqual(query.query.order.length, 1);
-    });
-  });
-
-  //
-  describe('SQL generation patterns', function() {
-    it('should generate correct WHERE EXISTS clause', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        status: 'SUBMITTED',
-        'applicant.last_name': 'Dupont%',
-        'applicant.email': 'test@example.com'
-      });
-
-      const sql = query.toSQL();
-
-      // Vérifier la structure de EXISTS
-      assert.ok(sql.sql.includes('WHERE `folders`.`status`'), 'Should have WHERE on folders.status');
-      assert.ok(sql.sql.includes('AND EXISTS (SELECT 1 FROM `applicants`'), 'Should have EXISTS with applicants');
-      assert.ok(sql.sql.includes('WHERE `applicants`.`id` = `folders`.`applicant_id`'), 'Should have join condition');
-    });
-
-    it('should handle LIKE patterns with %', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        'applicant.last_name': 'Dupont%'
-      });
-
-      const sql = query.toSQL();
-
-      // Le % dans la valeur devrait générer un LIKE
-      assert.ok(sql.sql.includes('LIKE'), 'Should generate LIKE for patterns with %');
-    });
-
-    it('should handle IN arrays', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        status: ['SUBMITTED', 'VALIDATED', 'APPROVED']
-      });
-
-      const sql = query.toSQL();
-
-      // Les tableaux devraient générer un IN
-      assert.ok(sql.sql.includes('IN'), 'Should generate IN for arrays');
-    });
-  });
-
-  //
-  describe('Performance optimization verification', function() {
-    it('COUNT should not include LEFT JOIN', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query
-        .where({
-          type: 'agp',
-          'applicant.last_name': 'Dupont%'
-        })
-        .join('pme_folder'); // Ce join ne doit pas apparaître dans COUNT
-
-      query.query.verb = 'count';
-      const sql = query.toSQL();
-
-      // Le COUNT ne doit pas avoir de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'COUNT should not have LEFT JOIN');
-
-      // Mais doit avoir EXISTS pour le filtre
-      assert.ok(sql.sql.includes('EXISTS'), 'COUNT should have EXISTS for filter');
-    });
-
-    it('IDS query should be minimal', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query.where({
-        type: 'agp',
-        'applicant.last_name': 'Dupont%'
-      })
-      .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier que seuls les IDs sont sélectionnés
-      assert.ok(sql.sql.includes('SELECT `folders`.`id`'), 'Should only select IDs');
-
-      // Pas de sélection d'autres colonnes
-      assert.ok(!sql.sql.includes('`folders`.*'), 'Should not select all columns');
-
-      // Pas de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'Should not have LEFT JOIN');
-    });
-  });
-
-  //
-  describe('Complex scenarios', function() {
-    it('should handle $and with multiple conditions', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        $and: [
-          { status: 'SUBMITTED' },
-          { 'applicant.last_name': 'Dupont%' },
-          { 'applicant.first_name': 'Jean%' }
-        ]
-      });
-
-      const sql = query.toSQL();
-
-      // Vérifier que les conditions sont présentes
-      assert.ok(sql.sql.includes('status'), 'Should include status condition');
-      assert.ok(sql.sql.includes('EXISTS'), 'Should include EXISTS for applicant');
-    });
-
-    it('should handle $or with multiple conditions', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        $or: [
-          { applicant_id: null },
-          { pme_folder_id: null }
-        ]
-      });
-
+      query.where({ $or: [{ applicant_id: null }, { pme_folder_id: null }] });
       const { sql, params } = query.toSQL();
 
       assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR `folders`.`pme_folder_id` IS NULL)'));
+      assert.deepStrictEqual(params, []);
     });
 
-    it('should include sibling conditions alongside $or', () => {
+    it('should generate $or with sibling condition (implicit AND)', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
       query.where({
         status: 'TRANSMIS',
-        $or: [
-          { applicant_id: null },
-          { pme_folder_id: null }
-        ]
+        $or: [{ applicant_id: null }, { pme_folder_id: null }]
       });
-
       const { sql, params } = query.toSQL();
 
       assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR `folders`.`pme_folder_id` IS NULL) AND `folders`.`status` = ?'));
       assert.deepStrictEqual(params, ['TRANSMIS']);
     });
 
-    it('should group multiple keys in one $or branch as implicit AND', () => {
+    it('should generate $or with implicit AND inside one branch', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
       query.where({
@@ -469,31 +344,13 @@ describe('db.PaginatedOptimizedQuery', function() {
           { pme_folder_id: null, type: 'agp' }
         ]
       });
-
       const { sql, params } = query.toSQL();
 
       assert.ok(sql.includes('WHERE (`folders`.`applicant_id` IS NULL OR (`folders`.`pme_folder_id` IS NULL AND `folders`.`type` = ?))'));
       assert.deepStrictEqual(params, ['agp']);
     });
 
-    it('should generate OR-ed EXISTS for $or with joined table conditions', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        $or: [
-          { 'applicant.last_name': 'Dupont%' },
-          { 'pme_folder.status': 'ACTIVE' }
-        ]
-      });
-
-      const { sql, params } = query.toSQL();
-
-      // Les deux EXISTS doivent être reliés par OR (pas AND)
-      assert.ok(sql.includes('(EXISTS (SELECT 1 FROM `applicants`'), 'Should have EXISTS on applicants');
-      assert.ok(sql.includes('OR EXISTS (SELECT 1 FROM `pme_folders`'), 'Should have OR EXISTS on pme_folders');
-    });
-
-    it('should support arbitrarily nested $or / $and expressions', () => {
+    it('should generate nested $or / $and at 3 levels', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
       query.where({
@@ -511,7 +368,6 @@ describe('db.PaginatedOptimizedQuery', function() {
           }
         ]
       });
-
       const { sql, params } = query.toSQL();
 
       assert.ok(sql.includes(
@@ -520,899 +376,342 @@ describe('db.PaginatedOptimizedQuery', function() {
       assert.deepStrictEqual(params, ['TRANS%', 'DRAFT', 'agp']);
     });
 
-    it('should combine main table and joined table filters', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        type: ['agp', 'avt', 'cga'],
-        status: 'SUBMITTED',
-        'applicant.last_name': 'Dupont%',
-        'pme_folder.status': 'ACTIVE'
-      });
-
-      const sql = query.toSQL();
-
-      // Vérifier que tous les WHERE sont présents
-      assert.ok(sql.sql.includes('`folders`.`type`'), 'Should include type filter');
-      assert.ok(sql.sql.includes('`folders`.`status`'), 'Should include status filter');
-      assert.ok(sql.sql.includes('EXISTS'), 'Should include EXISTS for filterJoin');
-
-      // Vérifier qu'il y a 2 EXISTS (applicant + pme_folder)
-      const existsCount = (sql.sql.match(/EXISTS/g) || []).length;
-      assert.ok(existsCount >= 2, 'Should have at least 2 EXISTS');
-    });
-  });
-
-  //
-  describe('Sorting on joined tables', function() {
-    it('should add INNER JOIN when sorting on joined table column', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({
-          type: ['agp', 'avt']
-        })
-        .order('applicants.last_name ASC')
-        .join('applicant')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier que l'INNER JOIN est présent
-      assert.ok(sql.sql.includes('LEFT JOIN'), 'SQL should contain LEFT JOIN for sorting on joined table');
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should INNER JOIN the applicants table');
-      assert.ok(sql.sql.includes('ON `applicants`.`id` = `folders`.`applicant_id`'), 'SQL should have correct join condition');
-
-      // Vérifier que le ORDER BY est présent
-      assert.ok(sql.sql.includes('ORDER BY applicants.last_name ASC'), 'SQL should have ORDER BY clause');
-    });
-
-    it('should NOT add INNER JOIN when sorting on main table column', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .order('folders.created_at DESC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier qu'il n'y a PAS de JOIN
-      assert.ok(!sql.sql.includes('INNER JOIN'), 'SQL should not contain INNER JOIN when sorting on main table');
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'SQL should not contain LEFT JOIN when sorting on main table');
-
-      // Vérifier que le ORDER BY est présent
-      assert.ok(sql.sql.includes('ORDER BY'), 'SQL should have ORDER BY clause');
-    });
-
-    it('should add INNER JOIN for nested sorted columns', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({
-          type: 'agp',
-          'pme_folder.company.country.code': 'FR'
-        })
-        .order('companies.name ASC')  // Tri sur une table imbriquée
-        .join('pme_folder.company.country')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier que les INNER JOIN en cascade sont présents
-      assert.ok(sql.sql.includes('LEFT JOIN `pme_folders`'), 'SQL should INNER JOIN pme_folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `companies`'), 'SQL should INNER JOIN companies');
-
-      // Vérifier le ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY companies.name ASC'), 'SQL should sort by companies.name');
-    });
-
-    it('should combine INNER JOIN for sorting with EXISTS for filtering', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({
-          type: 'agp',
-          'applicant.email': '%@example.com'
-        })
-        .order('applicants.last_name ASC')
-        .join('applicant')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier l'INNER JOIN pour le tri
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should have INNER JOIN for sorting');
-
-      // Vérifier EXISTS pour le filtre
-      assert.ok(sql.sql.includes('EXISTS'), 'SQL should have EXISTS for filtering');
-      assert.ok(sql.sql.includes('email'), 'SQL should filter on email');
-
-      // Vérifier ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY applicants.last_name ASC'), 'SQL should sort by applicants.last_name');
-    });
-
-    it('should NOT add INNER JOIN in COUNT phase even with sort on joined table', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query
-        .where({ type: 'agp' })
-        .order('applicants.last_name ASC')
-        .join('applicant')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // COUNT ne devrait PAS avoir de JOIN (même si on trie sur une table jointe)
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'COUNT should not have LEFT JOIN for sorting');
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'COUNT should not have LEFT JOIN');
-
-      // COUNT ne devrait PAS avoir de ORDER BY
-      assert.ok(!sql.sql.includes('ORDER BY'), 'COUNT should not have ORDER BY');
-    });
-
-    it('should transform association names to table names in ORDER BY (pmfp_folder.company case)', () => {
-      // Test pour vérifier que "pmfp_folder.company.name" devient "companies.name"
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .order('pme_folder.company.name ASC')
-        .join('pme_folder.company')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier les INNER JOIN en cascade
-      assert.ok(sql.sql.includes('LEFT JOIN `pme_folders`'), 'SQL should INNER JOIN pme_folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `companies`'), 'SQL should INNER JOIN companies');
-
-      // Vérifier que le ORDER BY utilise le nom de TABLE (companies) et non d'association (company)
-      assert.ok(sql.sql.includes('ORDER BY companies.name ASC'), 'SQL should use table name "companies" in ORDER BY');
-      assert.ok(!sql.sql.includes('company.name'), 'SQL should NOT use association name "company" in ORDER BY');
-    });
-  });
-
-  describe('ORDER BY avec Fonctions SQL', function() {
-    it('devrait gérer COALESCE avec plusieurs colonnes de la même table', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .join('applicant')
-        .order('COALESCE(`applicant`.`last_name`, `applicant`.`first_name`) ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit contenir l'INNER JOIN
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should INNER JOIN applicants');
-
-      // Doit conserver la fonction COALESCE dans ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY COALESCE'), 'SQL should preserve COALESCE function');
-      assert.ok(sql.sql.includes('applicants.last_name'), 'SQL should include last_name column (transformed from association to table name)');
-      assert.ok(sql.sql.includes('applicants.first_name'), 'SQL should include first_name column (transformed from association to table name)');
-    });
-
-    it('devrait gérer IFNULL avec table imbriquée', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'pme' })
-        .join('pme_folder.company')
-        .order('IFNULL(`companies`.`name`, "N/A") ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit contenir les INNER JOIN pour la chaîne d'associations
-      assert.ok(sql.sql.includes('LEFT JOIN `pme_folders`'), 'SQL should INNER JOIN pme_folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `companies`'), 'SQL should INNER JOIN companies');
-
-      // Doit conserver IFNULL dans ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY IFNULL'), 'SQL should preserve IFNULL function');
-    });
-
-    it('devrait gérer CONCAT avec colonnes multiples', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .join('applicant')
-        .order('CONCAT(`applicant`.`last_name`, " ", `applicant`.`first_name`) ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit contenir l'INNER JOIN
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should INNER JOIN applicants');
-
-      // Doit conserver CONCAT dans ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY CONCAT'), 'SQL should preserve CONCAT function');
-      assert.ok(sql.sql.includes('applicants.last_name'), 'SQL should include last_name column (transformed from association to table name)');
-      assert.ok(sql.sql.includes('applicants.first_name'), 'SQL should include first_name column (transformed from association to table name)');
-    });
-
-    it('devrait gérer COALESCE avec tables imbriquées', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'pme' })
-        .join('applicant')
-        .join('pme_folder.company')
-        .order('COALESCE(`applicant`.`last_name`, `companies`.`name`) ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit contenir les INNER JOIN
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should INNER JOIN applicants');
-      assert.ok(sql.sql.includes('LEFT JOIN `pme_folders`'), 'SQL should INNER JOIN pme_folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `companies`'), 'SQL should INNER JOIN companies');
-
-      // Doit conserver COALESCE dans ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY COALESCE'), 'SQL should preserve COALESCE function');
-    });
-
-    it('ne devrait pas ajouter de JOIN pour les fonctions sur la table principale', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .order('UPPER(`folders`.`name`) ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Ne doit pas contenir de INNER JOIN (seulement la table principale)
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'SQL should not contain LEFT JOIN for functions on main table');
-
-      // Doit conserver la fonction UPPER
-      assert.ok(sql.sql.includes('ORDER BY UPPER'), 'SQL should preserve UPPER function');
-    });
-
-    it('should not double-transform paths in COALESCE (idempotence)', () => {
-      // Test pour vérifier qu'il n'y a pas de double-transformation
-      // Ce test vérifie le bug: applicant.last_name dans un COALESCE
-      // ne doit PAS être transformé 2 fois et devenir applicants.something.last_name
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .join('applicant')
-        .join('pme_folder.company')
-        .order('COALESCE(applicant.last_name, applicant.first_name, pme_folder.company_name, companies.name) ASC')
-        .limit(25);
-
-      const sql = query.toSQL();
-
-      // Doit transformer correctement SANS double transformation
-      assert.ok(sql.sql.includes('applicants.last_name'), 'Should transform applicant to applicants');
-      assert.ok(sql.sql.includes('applicants.first_name'), 'Should transform applicant fields');
-      assert.ok(sql.sql.includes('pme_folders.company_name'), 'Should transform pme_folder to pme_folders');
-      assert.ok(sql.sql.includes('companies.name'), 'Should transform company to companies');
-
-      // NE DOIT PAS contenir de chemins avec 3 niveaux (double transformation)
-      assert.ok(!sql.sql.includes('.applicants.'), 'Should NOT have double-transformed paths like table.applicants.column');
-      assert.ok(!sql.sql.includes('.companies.'), 'Should NOT have double-transformed paths like table.companies.column');
-      assert.ok(!sql.sql.includes('.pme_folders.'), 'Should NOT have double-transformed paths like table.pme_folders.column');
-    });
-
-    it('transformation should be idempotent (_transformSinglePath)', () => {
-      // Test pour vérifier que transformer 2 fois donne le même résultat
-      const PaginatedOptimizedSql = require('../../src/db/PaginatedOptimizedSql');
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      const sqlGenerator = new PaginatedOptimizedSql(query);
-
-      const original = 'applicant.last_name';
-      const transformed1 = sqlGenerator._transformSinglePath(original);
-      const transformed2 = sqlGenerator._transformSinglePath(transformed1);
-
-      assert.strictEqual(transformed1, 'applicants.last_name',
-        'First transformation should give correct result');
-      assert.strictEqual(transformed1, transformed2,
-        'Transforming twice should give the same result (idempotent)');
-    });
-  });
-
-  describe('LEFT JOIN preserves rows with NULL', function() {
-    it('should use LEFT JOIN (not INNER JOIN) when sorting on joined table', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .order('applicants.last_name ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit utiliser LEFT JOIN, pas INNER JOIN
-      assert.ok(sql.sql.includes('LEFT JOIN'), 'SQL should use LEFT JOIN');
-      assert.ok(!sql.sql.includes('INNER JOIN'), 'SQL should not use INNER JOIN');
-
-      // Vérifier que c'est bien un LEFT JOIN sur applicants
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should LEFT JOIN applicants');
-
-      // Le ORDER BY doit être présent
-      assert.ok(sql.sql.includes('ORDER BY applicants.last_name ASC'), 'SQL should have ORDER BY');
-    });
-
-    it('should use LEFT JOIN for nested table sorting', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'pme' })
-        .order('pme_folder.company.name ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Tous les JOIN doivent être des LEFT JOIN
-      assert.ok(sql.sql.includes('LEFT JOIN'), 'SQL should use LEFT JOIN');
-      assert.ok(!sql.sql.includes('INNER JOIN'), 'SQL should not use INNER JOIN');
-
-      // Vérifier les LEFT JOIN en cascade
-      const leftJoinCount = (sql.sql.match(/LEFT JOIN/g) || []).length;
-      assert.ok(leftJoinCount >= 2, 'SQL should have at least 2 LEFT JOINs for nested path');
-    });
-
-    it('should use LEFT JOIN with SQL functions (COALESCE)', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .join('applicant')
-        .order('COALESCE(`applicant`.`last_name`, "Unknown") ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit utiliser LEFT JOIN même avec des fonctions SQL
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should LEFT JOIN applicants');
-      assert.ok(!sql.sql.includes('INNER JOIN'), 'SQL should not use INNER JOIN');
-    });
-
-    it('should verify LEFT JOIN preserves all rows conceptually', () => {
-      // Ce test vérifie que le SQL généré utilise LEFT JOIN
-      // qui préserve toutes les lignes, même celles avec NULL
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'select_ids';
-      query
-        .where({ type: 'agp' })
-        .order('applicants.last_name ASC')
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Vérifier structure SQL complète
-      assert.ok(sql.sql.includes('SELECT'), 'SQL should have SELECT');
-      assert.ok(sql.sql.includes('FROM `folders`'), 'SQL should have FROM folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `applicants`'), 'SQL should have LEFT JOIN applicants');
-      assert.ok(sql.sql.includes('WHERE `folders`.`type` = ?'), 'SQL should have WHERE clause');
-      assert.ok(sql.sql.includes('ORDER BY applicants.last_name ASC'), 'SQL should have ORDER BY');
-      assert.ok(sql.sql.includes('LIMIT'), 'SQL should have LIMIT');
-
-      // Avec LEFT JOIN, les folders sans applicant seront inclus avec last_name=NULL
-      // Ce comportement est correct et préserve toutes les lignes
-    });
-  });
-
-  //
-  describe('Advanced operators', function() {
-    it('should handle LIKE operator with % wildcard', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        'applicant.last_name': 'Dupont%'
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('LIKE'), 'Should generate LIKE for patterns with %');
-      assert.ok(sql.params.includes('Dupont%'), 'Should include the pattern in params');
-    });
-
-    it('should handle BETWEEN operator', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        created_at: { $between: ['2024-01-01', '2024-12-31'] }
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('BETWEEN'), 'Should generate BETWEEN operator');
-      assert.ok(sql.params.includes('2024-01-01'), 'Should include start date in params');
-      assert.ok(sql.params.includes('2024-12-31'), 'Should include end date in params');
-    });
-
-    it('should handle $gte operator', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        created_at: { $gte: '2024-01-01' }
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('>='), 'Should generate >= operator');
-      assert.ok(sql.params.includes('2024-01-01'), 'Should include date in params');
-    });
-
-    it('should handle $lte operator', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        created_at: { $lte: '2024-12-31' }
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('<='), 'Should generate <= operator');
-      assert.ok(sql.params.includes('2024-12-31'), 'Should include date in params');
-    });
-
-    it('should handle $like operator explicitly', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        'applicant.last_name': { $like: 'Dup%' }
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('LIKE'), 'Should generate LIKE');
-      assert.ok(sql.params.includes('Dup%'), 'Should include pattern in params');
-    });
-
-    it('should combine multiple advanced operators', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        created_at: { $between: ['2024-01-01', '2024-12-31'] },
-        status: ['SUBMITTED', 'VALIDATED'],
-        'applicant.last_name': 'Dupont%',
-        'applicant.email': '%@example.com'
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('LIKE'), 'Should generate LIKE');
-      assert.ok(sql.sql.includes('BETWEEN'), 'Should generate BETWEEN');
-      assert.ok(sql.sql.includes('IN'), 'Should generate IN');
-    });
-  });
-
-  //
-  describe('Edge cases', function() {
-    it('should handle null values', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        status: 'SUBMITTED',
-        deleted_at: null
-      });
-
-      const sql = query.toSQL();
-
-      assert.ok(sql.sql.includes('IS NULL'), 'Should generate IS NULL for null values');
-    });
-
-    it('should handle empty array', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
-      query.query.verb = 'count';
-      query.where({
-        status: []
-      });
-
-      const sql = query.toSQL();
-
-      // Un tableau vide devrait générer une condition qui est toujours fausse
-      // (Query.js le gère automatiquement)
-      assert.ok(sql.sql, 'Should generate SQL even with empty array');
-    });
-
-    it('should handle empty where object', () => {
+    it('should not produce WHERE clause for empty where({})', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
       query.where({});
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Devrait générer un SQL valide sans conditions
-      assert.ok(sql.sql.includes('SELECT COUNT(0)'), 'Should generate COUNT SQL');
-      assert.ok(!sql.sql.includes('WHERE'), 'Should not have WHERE clause for empty conditions');
+      assert.ok(sql.includes('SELECT COUNT(0)'));
+      assert.ok(!sql.includes('WHERE'));
+      assert.deepStrictEqual(params, []);
     });
   });
 
-  //
-  describe('Block tables (sub-tables) support', function() {
-    it('should detect ORDER BY on block column without prefix and add LEFT JOIN', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .order('studies_year DESC')  // Colonne dans block_studies, sans préfixe
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit ajouter un LEFT JOIN vers block_studies
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'SQL should LEFT JOIN block_studies for sorting on block column');
-      assert.ok(sql.sql.includes('ON `block_studies`.`id` = `pme_folders_with_blocks`.`block_studies_id`'), 'SQL should have correct join condition');
-
-      // Doit transformer ORDER BY en block_studies.studies_year
-      assert.ok(sql.sql.includes('ORDER BY block_studies.studies_year DESC'), 'SQL should prefix column with table name');
-    });
-
-    it('should handle multiple block columns in ORDER BY', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .order('studies_year DESC')
-        .order('bac_year ASC')  // Autre colonne du même block
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Un seul LEFT JOIN doit être ajouté (pas de duplication)
-      const leftJoinCount = (sql.sql.match(/LEFT JOIN `block_studies`/g) || []).length;
-      assert.strictEqual(leftJoinCount, 1, 'Should have exactly one LEFT JOIN to block_studies');
-
-      // Les deux colonnes doivent être préfixées
-      assert.ok(sql.sql.includes('ORDER BY block_studies.studies_year DESC'), 'Should prefix studies_year');
-      assert.ok(sql.sql.includes('block_studies.bac_year ASC'), 'Should prefix bac_year');
-    });
-
-    it('should handle ORDER BY on different blocks', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .order('studies_year DESC')  // Colonne dans block_studies
-        .order('destination ASC')    // Colonne dans block_travel_wishes
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Doit ajouter deux LEFT JOIN (un pour chaque block)
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'Should LEFT JOIN block_studies');
-      assert.ok(sql.sql.includes('LEFT JOIN `block_travel_wishes`'), 'Should LEFT JOIN block_travel_wishes');
-
-      // Les colonnes doivent être préfixées correctement
-      assert.ok(sql.sql.includes('ORDER BY block_studies.studies_year DESC'), 'Should prefix studies_year with block_studies');
-      assert.ok(sql.sql.includes('block_travel_wishes.destination ASC'), 'Should prefix destination with block_travel_wishes');
-    });
-
-    it('should NOT add JOIN if column exists in main table', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .order('professional_activity DESC')  // Colonne dans la table principale
-        .limit(50);
-
-      const sql = query.toSQL();
-
-      // Ne doit PAS ajouter de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'Should not add LEFT JOIN for main table column');
-
-      // ORDER BY doit rester simple
-      assert.ok(sql.sql.includes('ORDER BY professional_activity DESC'), 'Should keep simple ORDER BY for main table column');
-    });
-
-    it('should handle COUNT without JOIN for block ORDER BY', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+  // -------------------------------------------------------
+  // 3. EXISTS joins (verb 'count')
+  // -------------------------------------------------------
+  describe('EXISTS joins', function() {
+    it('should generate 1-level EXISTS', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'count';
-      query
-        .where({ is_initial: true })
-        .order('studies_year DESC')  // ORDER BY est ignoré dans COUNT
-        .limit(50);
+      query.where({ status: 'SUBMITTED', 'applicant.last_name': 'Dupont%' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // COUNT ne doit PAS avoir de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'COUNT should not have LEFT JOIN');
-
-      // COUNT ne doit PAS avoir de ORDER BY
-      assert.ok(!sql.sql.includes('ORDER BY'), 'COUNT should not have ORDER BY');
+      assert.ok(sql.includes('WHERE `folders`.`status` = ?'));
+      assert.ok(sql.includes('AND EXISTS (SELECT 1 FROM `applicants` WHERE `applicants`.`id` = `folders`.`applicant_id` AND `applicants`.`last_name` LIKE ? )'));
+      assert.deepStrictEqual(params, ['SUBMITTED', 'Dupont%']);
     });
 
-    it('should combine block ORDER BY with WHERE filters', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({
-          is_initial: true,
-          professional_activity: 'STUDENT'
-        })
-        .order('studies_year DESC')
-        .limit(50);
+    it('should group conditions on the same table into one EXISTS', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ 'applicant.last_name': 'Dupont%', 'applicant.email': 'test@test.com' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Doit avoir WHERE sur la table principale
-      assert.ok(sql.sql.includes('WHERE'), 'Should have WHERE clause');
-      assert.ok(sql.sql.includes('`pme_folders_with_blocks`.`is_initial`'), 'Should filter on is_initial');
-      assert.ok(sql.sql.includes('`pme_folders_with_blocks`.`professional_activity`'), 'Should filter on professional_activity');
-
-      // Doit avoir LEFT JOIN pour le tri
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'Should LEFT JOIN for ORDER BY');
-
-      // Doit avoir ORDER BY
-      assert.ok(sql.sql.includes('ORDER BY block_studies.studies_year DESC'), 'Should have ORDER BY on block column');
+      assert.ok(sql.includes('EXISTS (SELECT 1 FROM `applicants` WHERE `applicants`.`id` = `folders`.`applicant_id` AND `applicants`.`last_name` LIKE ? AND `applicants`.`email` = ? )'));
+      assert.strictEqual((sql.match(/EXISTS/g) || []).length, 1);
+      assert.deepStrictEqual(params, ['Dupont%', 'test@test.com']);
     });
 
-    it('should handle SQL functions with block columns', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .order('COALESCE(`studies_year`, "N/A") DESC')
-        .limit(50);
+    it('should generate 2 separate EXISTS for 2 different joined tables', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ 'applicant.last_name': 'Dupont%', 'pme_folder.status': 'ACTIVE' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Doit ajouter LEFT JOIN pour block_studies
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'Should LEFT JOIN block_studies');
-
-      // Doit transformer studies_year en block_studies.studies_year dans la fonction
-      assert.ok(sql.sql.includes('COALESCE'), 'Should preserve COALESCE function');
-      assert.ok(sql.sql.includes('block_studies.studies_year'), 'Should prefix column in function with table name');
+      assert.ok(sql.includes('EXISTS (SELECT 1 FROM `applicants` WHERE `applicants`.`id` = `folders`.`applicant_id` AND `applicants`.`last_name` LIKE ? )'));
+      assert.ok(sql.includes('EXISTS (SELECT 1 FROM `pme_folders` WHERE `pme_folders`.`id` = `folders`.`pme_folder_id` AND `pme_folders`.`status` = ? )'));
+      assert.strictEqual((sql.match(/EXISTS/g) || []).length, 2);
+      assert.deepStrictEqual(params, ['Dupont%', 'ACTIVE']);
     });
 
-    it('should work with explicit join() on block associations', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      query.query.verb = 'select_ids';
-      query
-        .where({ is_initial: true })
-        .join('studies')  // Join explicite sur l'association
-        .order('studies_year DESC')
-        .limit(50);
+    it('should generate deeply nested EXISTS (3 levels)', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ 'pme_folder.company.country.code': 'FR' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Même comportement : LEFT JOIN ajouté
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'Should LEFT JOIN block_studies');
-      assert.ok(sql.sql.includes('ORDER BY block_studies.studies_year DESC'), 'Should prefix column with table name');
+      assert.ok(sql.includes(
+        'EXISTS (SELECT 1 FROM `pme_folders` WHERE `pme_folders`.`id` = `folders`.`pme_folder_id` ' +
+        'AND EXISTS (SELECT 1 FROM `companies` WHERE `companies`.`id` = `pme_folders`.`company_id` ' +
+        'AND EXISTS (SELECT 1 FROM `countries` WHERE `countries`.`id` = `companies`.`country_id` ' +
+        'AND `countries`.`code` = ? ) ) )'
+      ));
+      assert.strictEqual((sql.match(/EXISTS/g) || []).length, 3);
+      assert.deepStrictEqual(params, ['FR']);
     });
 
-    it('should transform nested association paths in ORDER BY for phase FULL', () => {
-      // Test pour vérifier que les chemins d'associations imbriqués sont transformés
-      // dans la phase FULL (qui utilise Query standard, pas PaginatedOptimizedSql)
+    it('should generate OR-ed EXISTS for $or with joined table conditions', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({
+        $or: [
+          { 'applicant.last_name': 'Dupont%' },
+          { 'pme_folder.status': 'ACTIVE' }
+        ]
+      });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('(EXISTS (SELECT 1 FROM `applicants`'));
+      assert.ok(sql.includes('OR EXISTS (SELECT 1 FROM `pme_folders`'));
+      assert.deepStrictEqual(params, ['Dupont%', 'ACTIVE']);
+    });
+
+    it('should include extraWhere in EXISTS clause', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(BookWithExtraWhere));
+      query.query.verb = 'count';
+      query.where({ 'library.title': 'Test%' });
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('EXISTS (SELECT 1 FROM `libraries` WHERE `libraries`.`id` = `books`.`library_id` AND `libraries`.`collection` = ?'));
+      assert.ok(sql.includes('`libraries`.`title` LIKE ?'));
+      assert.deepStrictEqual(params, ['A', 'Test%']);
+    });
+  });
+
+  // -------------------------------------------------------
+  // 4. COUNT and IDS phases (optimizations)
+  // -------------------------------------------------------
+  describe('COUNT and IDS phase optimizations', function() {
+    it('COUNT should have no LEFT JOIN, no ORDER BY, and use EXISTS for filters', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'count';
+      query.where({ type: 'agp', 'applicant.last_name': 'Dupont%' })
+        .order('applicants.last_name ASC')
+        .join('applicant');
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('SELECT COUNT(0)'));
+      assert.ok(sql.includes('EXISTS'));
+      assert.ok(!sql.includes('LEFT JOIN'));
+      assert.ok(!sql.includes('ORDER BY'));
+      assert.deepStrictEqual(params, ['agp', 'Dupont%']);
+    });
+
+    it('IDS should SELECT only id, use EXISTS, ORDER BY + LIMIT, and no LEFT JOIN when sort is on main table', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'select_ids';
-      query
-        .where({ type: 'pme' })
-        .join('pme_folder.company')
-        .order('pme_folder.company.name ASC')  // Chemin d'association imbriqué
+      query.where({ type: 'agp', 'applicant.last_name': 'Dupont%' })
+        .order('folders.created_at DESC')
         .limit(50);
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Dans la phase IDS, le ORDER BY doit être transformé
-      assert.ok(sql.sql.includes('ORDER BY companies.name ASC'), 'Should transform nested path to table name in IDS phase');
+      assert.ok(sql.includes('SELECT `folders`.`id`'));
+      assert.ok(sql.includes('EXISTS (SELECT 1 FROM `applicants`'));
+      assert.ok(sql.includes('ORDER BY folders.created_at DESC'));
+      assert.ok(sql.includes('LIMIT ?, ?'));
+      assert.ok(!sql.includes('LEFT JOIN'));
+      assert.deepStrictEqual(params, ['agp', 'Dupont%', 0, 50]);
     });
+  });
 
-    it('should transform nested block paths with dot notation (association.block.column)', () => {
-      // Test pour vérifier que les chemins imbriqués vers des blocks sont transformés
-      // Exemple : pme_folder.company.name doit être transformé en companies.name
+  // -------------------------------------------------------
+  // 5. Sort on joined tables
+  // -------------------------------------------------------
+  describe('Sort on joined tables', function() {
+    it('should add LEFT JOIN when sorting on a joined table column', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
       query.query.verb = 'select_ids';
-      query
-        .where({ type: 'pme' })
-        .join('pme_folder.company')
-        .order('pme_folder.company.name ASC')
-        .limit(50);
+      query.where({ type: 'agp' }).order('applicants.last_name ASC').limit(50);
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Le ORDER BY doit être transformé
-      assert.ok(sql.sql.includes('ORDER BY companies.name ASC'),
-        'Should transform pme_folder.company.name to companies.name in ORDER BY');
+      assert.ok(sql.includes('LEFT JOIN `applicants` ON `applicants`.`id` = `folders`.`applicant_id`'));
+      assert.ok(sql.includes('ORDER BY applicants.last_name ASC'));
+      assert.ok(!sql.includes('INNER JOIN'));
+      assert.deepStrictEqual(params, ['agp', 0, 50]);
     });
 
-    it('should handle nested path to block with 3 levels (folder.pme_folder.block_study.column)', () => {
-      // Test pour la hiérarchie complète : Folder -> PMEFolder -> StudiesBlock
-      // Ce test correspond au cas réel de l'utilisateur
+    it('should add cascading LEFT JOINs for nested sort path', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'select_ids';
+      query.where({ type: 'pme' }).order('pme_folder.company.name ASC').limit(50);
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('LEFT JOIN `pme_folders` ON `pme_folders`.`id` = `folders`.`pme_folder_id`'));
+      assert.ok(sql.includes('LEFT JOIN `companies` ON `companies`.`id` = `pme_folders`.`company_id`'));
+      assert.ok(sql.includes('ORDER BY companies.name ASC'));
+      assert.strictEqual((sql.match(/LEFT JOIN/g) || []).length, 2);
+      assert.deepStrictEqual(params, ['pme', 0, 50]);
+    });
+
+    it('should not add any JOIN when sorting on main table column', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'select_ids';
+      query.where({ type: 'agp' }).order('folders.created_at DESC').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(!sql.includes('LEFT JOIN'));
+      assert.ok(!sql.includes('INNER JOIN'));
+      assert.ok(sql.includes('ORDER BY folders.created_at DESC'));
+    });
+
+    it('should transform association name to table name in ORDER BY', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'select_ids';
+      query.where({ type: 'agp' }).order('pme_folder.company.name ASC').join('pme_folder.company').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(sql.includes('ORDER BY companies.name ASC'));
+      assert.ok(!sql.includes('company.name'));
+    });
+
+    it('should preserve SQL functions (COALESCE, CONCAT, IFNULL) in ORDER BY', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      query.query.verb = 'select_ids';
+      query.where({ type: 'agp' }).join('applicant')
+        .order('COALESCE(`applicant`.`last_name`, `applicant`.`first_name`) ASC')
+        .limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(sql.includes('LEFT JOIN `applicants`'));
+      assert.ok(sql.includes('ORDER BY COALESCE(applicants.last_name, applicants.first_name) ASC'));
+    });
+
+    it('should be idempotent when transforming paths (_transformSinglePath)', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(Folder));
+      const sqlGenerator = new PaginatedOptimizedSql(query);
+
+      const transformed1 = sqlGenerator._transformSinglePath('applicant.last_name');
+      const transformed2 = sqlGenerator._transformSinglePath(transformed1);
+
+      assert.strictEqual(transformed1, 'applicants.last_name');
+      assert.strictEqual(transformed1, transformed2);
+    });
+
+  });
+
+  // -------------------------------------------------------
+  // 6. Block tables
+  // -------------------------------------------------------
+  describe('Block tables', function() {
+    it('should add LEFT JOIN and prefix ORDER BY for a block column', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      query.query.verb = 'select_ids';
+      query.where({ is_initial: true }).order('studies_year DESC').limit(50);
+      const { sql, params } = query.toSQL();
+
+      assert.ok(sql.includes('LEFT JOIN `block_studies` ON `block_studies`.`id` = `pme_folders_with_blocks`.`block_studies_id`'));
+      assert.ok(sql.includes('ORDER BY block_studies.studies_year DESC'));
+      assert.deepStrictEqual(params, [true, 0, 50]);
+    });
+
+    it('should deduplicate LEFT JOINs when multiple columns from the same block', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      query.query.verb = 'select_ids';
+      query.where({ is_initial: true }).order('studies_year DESC').order('bac_year ASC').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.strictEqual((sql.match(/LEFT JOIN `block_studies`/g) || []).length, 1);
+      assert.ok(sql.includes('ORDER BY block_studies.studies_year DESC, block_studies.bac_year ASC'));
+    });
+
+    it('should add separate LEFT JOINs for columns from different blocks', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      query.query.verb = 'select_ids';
+      query.where({ is_initial: true }).order('studies_year DESC').order('destination ASC').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(sql.includes('LEFT JOIN `block_studies`'));
+      assert.ok(sql.includes('LEFT JOIN `block_travel_wishes`'));
+      assert.ok(sql.includes('ORDER BY block_studies.studies_year DESC, block_travel_wishes.destination ASC'));
+    });
+
+    it('should not add JOIN when sorting on a main table column', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      query.query.verb = 'select_ids';
+      query.where({ is_initial: true }).order('professional_activity DESC').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(!sql.includes('LEFT JOIN'));
+      assert.ok(sql.includes('ORDER BY professional_activity DESC'));
+    });
+
+    it('should handle nested path 3 levels (folder -> pme_folder -> block_study)', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(FolderWithNestedBlocks));
       query.query.verb = 'select_ids';
-      query
-        .where({ type: ['agp', 'avt'] })
-        .order('pme_folder.block_study.bac_year DESC')  // Chemin imbriqué vers un block
-        .limit(50);
+      query.where({ type: ['agp', 'avt'] }).order('pme_folder.block_study.bac_year DESC').limit(50);
+      const { sql } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Doit ajouter les LEFT JOIN nécessaires
-      assert.ok(sql.sql.includes('LEFT JOIN `pme_folders`'), 'Should LEFT JOIN pme_folders');
-      assert.ok(sql.sql.includes('LEFT JOIN `block_studies`'), 'Should LEFT JOIN block_studies');
-
-      // Doit avoir les bonnes conditions de jointure
-      assert.ok(sql.sql.includes('ON `pme_folders`.`id` = `folders`.`pme_folder_id`'),
-        'Should have correct join condition for pme_folders');
-      assert.ok(sql.sql.includes('ON `block_studies`.`id` = `pme_folders`.`block_studies_id`'),
-        'Should have correct join condition for block_studies');
-
-      // Le ORDER BY doit être transformé
-      assert.ok(sql.sql.includes('ORDER BY block_studies.bac_year DESC'),
-        'Should transform pme_folder.block_study.bac_year to block_studies.bac_year');
+      assert.ok(sql.includes('LEFT JOIN `pme_folders` ON `pme_folders`.`id` = `folders`.`pme_folder_id`'));
+      assert.ok(sql.includes('LEFT JOIN `block_studies` ON `block_studies`.`id` = `pme_folders`.`block_studies_id`'));
+      assert.ok(sql.includes('ORDER BY block_studies.bac_year DESC'));
     });
 
-    it('should transform ORDER BY correctly for FULL phase with block columns', () => {
-      // Test pour vérifier que la transformation pour la phase FULL utilise les alias (noms d'associations)
-      // au lieu des noms de tables
-      const PaginatedOptimizedSql = require('../../src/db/PaginatedOptimizedSql');
+    it('should transform nested path correctly for FULL phase (alias vs table name)', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(FolderWithNestedBlocks));
-
-      query
-        .where({ type: ['agp', 'avt'] })
-        .order('pme_folder.block_study.bac_year')  // Chemin imbriqué
-        .order('created_at DESC')  // Colonne de la table principale
-        .limit(50);
+      query.where({ type: ['agp', 'avt'] }).order('pme_folder.block_study.bac_year').limit(50);
 
       const sqlGenerator = new PaginatedOptimizedSql(query);
 
-      // Test de transformation pour phase IDS (noms de tables)
-      const transformedForIDS = sqlGenerator._transformOrderClause('pme_folder.block_study.bac_year');
-      assert.strictEqual(transformedForIDS, 'block_studies.bac_year',
-        'IDS phase should use table name (block_studies)');
+      const idsTransform = sqlGenerator._transformOrderClause('pme_folder.block_study.bac_year');
+      assert.strictEqual(idsTransform, 'block_studies.bac_year');
 
-      // Test de transformation pour phase FULL (noms d'associations = alias)
-      const transformedForFULL = sqlGenerator._transformOrderClauseForFullQuery('pme_folder.block_study.bac_year');
-      assert.strictEqual(transformedForFULL, 'block_study.bac_year',
-        'FULL phase should use association name as alias (block_study)');
+      const fullTransform = sqlGenerator._transformOrderClauseForFullQuery('pme_folder.block_study.bac_year');
+      assert.strictEqual(fullTransform, 'block_study.bac_year');
 
-      // Test avec colonne simple de block (uniquement pour modèles avec associations directes)
-      const queryWithBlocks = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
-      const sqlGeneratorWithBlocks = new PaginatedOptimizedSql(queryWithBlocks);
-      const transformedSimpleForFULL = sqlGeneratorWithBlocks._transformOrderClauseForFullQuery('studies_year');
-      assert.strictEqual(transformedSimpleForFULL, 'studies.studies_year',
-        'FULL phase should find block association for simple column name in direct associations');
+      const queryBlocks = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      const sqlGenBlocks = new PaginatedOptimizedSql(queryBlocks);
+      assert.strictEqual(sqlGenBlocks._transformOrderClauseForFullQuery('studies_year'), 'studies.studies_year');
+    });
+
+    it('should handle COALESCE with block column', () => {
+      const query = mockGetDb(new PaginatedOptimizedQuery(PMEFolderWithBlocks));
+      query.query.verb = 'select_ids';
+      query.where({ is_initial: true }).order('COALESCE(`studies_year`, "N/A") DESC').limit(50);
+      const { sql } = query.toSQL();
+
+      assert.ok(sql.includes('LEFT JOIN `block_studies`'));
+      assert.ok(sql.includes('COALESCE(block_studies.studies_year'));
     });
   });
 
-  //
-  describe('extraWhere support in PaginatedOptimizedQuery', function() {
-    // Modèle avec extraWhere sur l'association
-    class Library extends Model({
-      table: 'libraries',
-      primary: ['id'],
-      columns: {
-        id: 'integer',
-        title: 'string',
-        collection: 'string'
-      }
-    }) {}
-
-    class BookWithExtraWhere extends Model({
-      table: 'books',
-      primary: ['id'],
-      columns: {
-        id: 'integer',
-        code: 'string',
-        title: 'string',
-        library_id: 'integer'
-      },
-      associations: () => ([
-        ['belongs_to', 'library', Library, 'library_id', 'id', { collection: 'A' }]
-      ])
-    }) {}
-
-    it('should apply extraWhere in EXISTS clause for filterJoin', () => {
-      const query = mockGetDb(new PaginatedOptimizedQuery(BookWithExtraWhere));
-      query.query.verb = 'count';
-      query.where({
-        'library.title': 'Test%'
-      });
-
-      const sql = query.toSQL();
-
-      // Vérifier que EXISTS est présent
-      assert.ok(sql.sql.includes('EXISTS'), 'SQL should contain EXISTS');
-
-      // Vérifier que extraWhere est inclus dans la clause EXISTS
-      assert.ok(sql.sql.includes('`libraries`.`collection`'), 'SQL should include extraWhere column');
-      assert.ok(sql.params.includes('A'), 'SQL params should include extraWhere value');
-
-      // Le SQL devrait ressembler à :
-      // EXISTS (SELECT 1 FROM `libraries` WHERE `libraries`.`id` = `books`.`library_id` AND `libraries`.`collection` = ? AND `libraries`.`title` LIKE ?)
-    });
-
-    it('should apply extraWhere in LEFT JOIN for sorting', () => {
+  // -------------------------------------------------------
+  // 7. extraWhere on associations
+  // -------------------------------------------------------
+  describe('extraWhere on associations', function() {
+    it('should apply extraWhere in LEFT JOIN condition (verb select_ids)', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(BookWithExtraWhere));
       query.query.verb = 'select_ids';
-      query
-        .where({ code: 'ABC' })
-        .order('library.title ASC')
-        .limit(50);
+      query.where({ code: 'ABC' }).order('library.title ASC').limit(50);
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Vérifier que LEFT JOIN est présent
-      assert.ok(sql.sql.includes('LEFT JOIN `libraries`'), 'SQL should contain LEFT JOIN');
-
-      // Vérifier que extraWhere est inclus dans la condition du JOIN
-      assert.ok(sql.sql.includes('`libraries`.`collection` = ?'), 'SQL should include extraWhere in JOIN condition');
-      assert.ok(sql.params.includes('A'), 'SQL params should include extraWhere value');
-
-      // Le SQL devrait ressembler à :
-      // LEFT JOIN `libraries` ON `libraries`.`id` = `books`.`library_id` AND `libraries`.`collection` = ?
+      assert.ok(sql.includes('LEFT JOIN `libraries` ON `libraries`.`id` = `books`.`library_id` AND `libraries`.`collection` = ?'));
+      assert.ok(params.includes('A'));
     });
 
-    it('should apply extraWhere in both EXISTS (filter) and LEFT JOIN (sort)', () => {
+    it('should apply extraWhere in both EXISTS and LEFT JOIN when combined', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(BookWithExtraWhere));
       query.query.verb = 'select_ids';
-      query
-        .where({
-          code: 'ABC',
-          'library.title': 'Test%'
-        })
-        .order('library.title ASC')
-        .limit(50);
+      query.where({ code: 'ABC', 'library.title': 'Test%' }).order('library.title ASC').limit(50);
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Vérifier que EXISTS et LEFT JOIN sont présents
-      assert.ok(sql.sql.includes('EXISTS'), 'SQL should contain EXISTS');
-      assert.ok(sql.sql.includes('LEFT JOIN'), 'SQL should contain LEFT JOIN');
-
-      // Vérifier que extraWhere apparaît 2 fois (une fois dans EXISTS, une fois dans JOIN)
-      const collectionMatches = sql.sql.match(/`libraries`\.`collection`/g) || [];
-      assert.strictEqual(collectionMatches.length, 2, 'extraWhere should appear twice (EXISTS + JOIN)');
-
-      // Vérifier que 'A' est dans les params deux fois
-      const aParams = sql.params.filter(p => p === 'A');
-      assert.strictEqual(aParams.length, 2, 'extraWhere value should appear twice in params');
+      assert.ok(sql.includes('EXISTS'));
+      assert.ok(sql.includes('LEFT JOIN'));
+      assert.strictEqual((sql.match(/`libraries`\.`collection`/g) || []).length, 2);
+      assert.strictEqual(params.filter(p => p === 'A').length, 2);
     });
 
-    it('should NOT include extraWhere in COUNT (no JOIN needed)', () => {
+    it('COUNT should not include LEFT JOIN even with extraWhere sort', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(BookWithExtraWhere));
       query.query.verb = 'count';
-      query
-        .where({ code: 'ABC' })
-        .order('library.title ASC');  // ORDER BY ignored in COUNT
+      query.where({ code: 'ABC' }).order('library.title ASC');
+      const { sql } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // COUNT ne devrait pas avoir de LEFT JOIN
-      assert.ok(!sql.sql.includes('LEFT JOIN'), 'COUNT should not have LEFT JOIN');
-
-      // COUNT ne devrait pas avoir de ORDER BY
-      assert.ok(!sql.sql.includes('ORDER BY'), 'COUNT should not have ORDER BY');
-
-      // Mais si on avait un filtre sur library, on aurait EXISTS avec extraWhere
+      assert.ok(!sql.includes('LEFT JOIN'));
+      assert.ok(!sql.includes('ORDER BY'));
     });
-
-    // Test avec plusieurs conditions extraWhere
-    class BookWithMultipleExtraWhere extends Model({
-      table: 'books_multi',
-      primary: ['id'],
-      columns: {
-        id: 'integer',
-        title: 'string',
-        library_id: 'integer'
-      },
-      associations: () => ([
-        ['belongs_to', 'library', Library, 'library_id', 'id', { collection: 'A', title: 'Main' }]
-      ])
-    }) {}
 
     it('should apply multiple extraWhere conditions', () => {
       const query = mockGetDb(new PaginatedOptimizedQuery(BookWithMultipleExtraWhere));
       query.query.verb = 'count';
-      query.where({
-        'library.title': 'Test%'
-      });
+      query.where({ 'library.title': 'Test%' });
+      const { sql, params } = query.toSQL();
 
-      const sql = query.toSQL();
-
-      // Vérifier que les deux conditions extraWhere sont présentes
-      assert.ok(sql.sql.includes('`libraries`.`collection`'), 'SQL should include collection extraWhere');
-      assert.ok(sql.sql.includes('`libraries`.`title`'), 'SQL should include title in filter condition');
-      assert.ok(sql.params.includes('A'), 'SQL params should include collection value');
-      assert.ok(sql.params.includes('Main'), 'SQL params should include title extraWhere value');
+      assert.ok(sql.includes('`libraries`.`collection` = ?'));
+      assert.ok(sql.includes('`libraries`.`title`'));
+      assert.ok(params.includes('A'));
+      assert.ok(params.includes('Main'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Fix $or** : les conditions siblings (ex: `status: 'TRANSMIS'`) étaient ignorées quand `$or` était présent dans le même `where()`. Les clés multiples dans une branche `$or` étaient aplaties en OR au lieu d'être groupées en AND implicite.
- **Refactoring expression compiler** : remplacement de 4 méthodes de parsing (`_parseWhereConditions`, `_parseConditionObject`, `_transformOperator`, `_handleOrWithJoinedTables`) par 2 méthodes récursives (`_compileExpression`, `_compileSingleCondition`). Supporte l'imbrication arbitraire de `$and`/`$or` à tous les niveaux, y compris avec des conditions sur tables jointes (OR-ed EXISTS).
- **Réécriture des tests** : 64 → 39 tests, réorganisés en 7 blocs thématiques. Assertions exhaustives sur le SQL généré (clauses WHERE complètes) au lieu de fragments partiels.

## Exemples de syntaxes désormais supportées

```js
// $or avec condition sibling (fix)
query.where({ status: 'TRANSMIS', $or: [{ user_id: null }, { referent_id: null }] })
// → WHERE (... IS NULL OR ... IS NULL) AND status = ?

// Imbrication arbitraire (nouveau)
query.where({
  type: 'agp',
  $or: [
    { applicant_id: null },
    { $and: [{ pme_folder_id: null }, { $or: [{ status: { $like: 'TRANS%' } }, { status: 'DRAFT' }] }] }
  ]
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)